### PR TITLE
[MIC-7455] Lint local podspecs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,18 +42,37 @@ lane :extend_bump_version do |options|
 end
 
 lane :check do
-    # Linting ruby files
-    lint_fastfile
+  # Linting ruby files
+  lint_fastfile
 
-    # Linting podspec
-    podspec_names = Dir.glob('*.podspec', base: '..').map { |f| File.basename(f, '.*') }
-    include_podspecs = "{#{podspec_names.join(',')}}.podspec"
-    pod_lib_lint(allow_warnings: true, include_podspecs: include_podspecs)
+  # Linting podspecs
+  lint_all_podspecs
 
-    # Buidling Swift package
-    if(File.exist?('Package.swift'))
-        build_swift_package
-    end
+  # Buidling Swift package
+  build_swift_package if File.exist?('Package.swit')
+end
+
+lane :lint_all_podspecs do 
+  Dir.chdir("..") do
+    sh("bundle exec pod repo update")
+  end
+  all_pods_dependencies = scan_local_podspec_dependencies
+
+  Dir.glob('*.podspec', base: '..').each do |podspec_path|
+    podspec_name = File.basename(podspec_path, '.podspec')
+    pod_dependencies = all_pods_dependencies[podspec_name]
+    include_podspecs = nil
+    # We need include only necessary local podspecs, not all!
+    include_podspecs = "{#{pod_dependencies.sort.join(',')}}.podspec" unless pod_dependencies.empty?
+    
+    pod_lib_lint(
+      podspec: podspec_path,
+      include_podspecs: include_podspecs,
+      allow_warnings: true,
+      skip_tests: true,
+      fail_fast: true
+    )
+  end
 end
 
 lane :build_swift_package do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,9 +112,11 @@ def push_podspec(podspec_name)
     begin
       sh("bundle exec pod repo update")
       pod_push(
+        use_bundle_exec: true,
         path: podspec_name,
         allow_warnings: true,
-        skip_tests: true
+        skip_tests: true,
+        synchronous: true
       )
       break
     rescue StandardError => error

--- a/fastlane/actions/scan_local_podspec_dependencies.rb
+++ b/fastlane/actions/scan_local_podspec_dependencies.rb
@@ -1,0 +1,65 @@
+require 'cocoapods-core'
+
+module Fastlane
+  module Actions
+    class ScanLocalPodspecDependenciesAction < Action
+      def self.run(params)
+        all_dependencies = {}
+        Dir.glob('*.podspec').each do |path|
+          podspec = Pod::Spec.from_file(File.expand_path(path)).to_hash
+          dependencies = Set.new
+          name = podspec['name']
+          scan_dependencies(podspec, name, dependencies)
+          all_dependencies[name] = dependencies.to_a
+        end
+        local_names = all_dependencies.keys
+        all_dependencies.each_value do |dependencies|
+          dependencies.filter! { |name| local_names.include?(name) }
+        end
+
+        loop do
+          changes_count = 0
+          all_dependencies.each do |name, dependencies|
+            dependencies.each do |dependency_name|
+              all_dependencies[dependency_name].each do |dependency_name_l2|
+                if !dependencies.include?(dependency_name_l2) && name != dependency_name_l2
+                  dependencies.append(dependency_name_l2)
+                  changes_count += 1
+                end
+              end
+            end
+          end
+          break if changes_count == 0
+        end
+        all_dependencies
+      end
+
+      def self.scan_dependencies(spec, name, out)
+        dependencies = spec['dependencies']
+        if dependencies.kind_of?(Hash)
+          dependencies.each_key do |dependency_name|
+            pod_name = dependency_name.gsub(%r{/.+}, '')
+            out.add(pod_name) if pod_name != name
+          end
+        end
+        subspecs = spec['subspecs']
+        ['ios', 'watchos', 'macos', 'tvos'].each do |platform|
+          platform_spec = spec[platform]
+          if platform_spec.kind_of?(Hash)
+            scan_dependencies(platform_spec, name, out)
+          end
+        end
+        if subspecs.kind_of?(Array)
+          subspecs.each do |subspec|
+            scan_dependencies(subspec, name, out)
+          end
+        end
+        testspecs = spec['testspecs']
+        testspecs.each { |ts| scan_dependencies(ts, name, out) } if testspecs.kind_of?(Array)
+
+        appspecs = spec['appspecs']
+        appspecs.each { |s| scan_dependencies(s, name, out) } if appspecs.kind_of?(Array)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Добавил экшен `scan_local_podspec_dependencies`
- Заменил логику линтовки спек. Теперь каждая спека проверяется отдельно, используя свои локальные зависимости
- Добавил опцию [synchronous](https://github.com/CocoaPods/cocoapods-trunk/pull/147) в pod_push. Вроде должно помочь последовательным пушем нескольких спек
