### PR TITLE
Publish improvements

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,10 +4,12 @@ lane :release do |options|
 
   # Checking that everything is alright
   check
-  podspec_names = Dir.glob('*.podspec', base: '..')
+  podspec_names = sorted_podspecs(podspecs:Dir.glob('*.podspec', base: '..'))
   # Bumping podspec version
   for podspec_name in podspec_names
     version = version_bump_podspec(path: podspec_name, bump_type: bump_type)
+
+    bump_podspec_dependency(podspecs: podspec_names, name: podspec_name.delete_suffix('.podspec'), version: version)
   end
 
   add_files = extend_bump_version(version: version)
@@ -108,7 +110,7 @@ end
 
 def push_podspec(podspec_name)
   tries = 6
-  for i in 1..tries
+  (1..tries).each do |i|
     begin
       sh("bundle exec pod repo update")
       pod_push(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,7 +110,7 @@ end
 
 def push_podspec(podspec_name)
   tries = 6
-  (1..tries).each do |i|
+  for i in 1..tries
     begin
       sh("bundle exec pod repo update")
       pod_push(

--- a/fastlane/actions/bump_podspec_dependency.rb
+++ b/fastlane/actions/bump_podspec_dependency.rb
@@ -1,0 +1,51 @@
+module Fastlane
+  module Actions
+    class BumpPodspecDependencyAction < Action
+      def self.run(params)
+        podspecs = params[:podspecs]
+        name = params[:name]
+        version = params[:version]
+        regexp = %r{(\.dependency\s+['"]#{Regexp.escape(name)}(?:/[^/'"]+)*['"]\s*,\s*['"])(?:[^'"]+)(['"])}m
+        affected_podspecs = []
+        podspecs.each do |podspec|
+          UI.message("replacing #{regexp}")
+          content = File.read(podspec)
+          new_content = content.gsub(regexp, "\\1#{version}\\2")
+          if new_content != content
+            File.write(podspec, new_content)
+            affected_podspecs.append(podspec)
+          end
+        end
+        if affected_podspecs.empty?
+          UI.important("No affected podspecs for dependency '#{name}'")
+        else
+          UI.success("Update dependency '#{name}' to version #{version} in #{affected_podspecs.join(', ')}")
+        end
+        affected_podspecs
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :podspecs,
+            description: 'Podspec path list',
+            type: Array,
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :name,
+            description: 'Dependency name (example: Alamofire)',
+            type: String,
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :version,
+            description: 'Dependency version (example: \'~> 1.2.3\')',
+            type: String,
+            optional: false
+          )
+        ]
+      end
+    end
+  end
+end

--- a/fastlane/actions/sorted_podspecs.rb
+++ b/fastlane/actions/sorted_podspecs.rb
@@ -1,0 +1,93 @@
+require 'cocoapods'
+require 'tsort'
+
+module Fastlane
+  module Actions
+    class SortedPodspecsAction < Action
+      def self.run(params)
+        @podspecs = params[:podspecs].map { |filename| Fastlane::Helper::Podspec.new(filename) }
+
+        tsort.map(&:path)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Returns a list of podspecs sorted by dependency'
+      end
+
+      def self.details
+        # Optional:
+        # this is your chance to provide a more detailed description of this action
+        'Parses podspec from a given list and topologically sorts them by dependency'
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :podspecs,
+            description: 'Podspec path list',
+            type: Array,
+            optional: false
+          )
+        ]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ['adarovsky']
+      end
+
+      #####################################################
+      # @!group Sorting
+      #####################################################
+
+      def self.tsort_each_node(&block)
+        @podspecs.each(&block)
+      end
+
+      def self.tsort_each_child(node, &block)
+        node
+          .dependencies
+          .filter_map { |d| @podspecs.find { |e| e.name == d.name } }
+          .each(&block)
+      end
+
+      extend TSort
+    end
+  end
+
+  module Helper
+    class Podspec
+
+      attr_reader :path
+
+      # @param [String] path
+      def initialize(path)
+        @path = path
+        @spec = Pod::Spec.from_file(path)
+      end
+
+      def dependencies
+        @spec.dependencies
+      end
+
+      def name
+        @spec.name
+      end
+
+      def to_s
+        "#{@spec}: #{path}/#{@spec.name}.podspec"
+      end
+    end
+  end
+end

--- a/fastlane/actions/sorted_podspecs.rb
+++ b/fastlane/actions/sorted_podspecs.rb
@@ -19,8 +19,6 @@ module Fastlane
       end
 
       def self.details
-        # Optional:
-        # this is your chance to provide a more detailed description of this action
         'Parses podspec from a given list and topologically sorts them by dependency'
       end
 
@@ -39,11 +37,10 @@ module Fastlane
       end
 
       def self.return_value
-        # If your method provides a return value, you can describe here what it does
+        'An original list of podspec filenames sorted by dependency'
       end
 
       def self.authors
-        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
         ['adarovsky']
       end
 
@@ -83,10 +80,6 @@ module Fastlane
 
       def name
         @spec.name
-      end
-
-      def to_s
-        "#{@spec}: #{path}/#{@spec.name}.podspec"
       end
     end
   end


### PR DESCRIPTION
When publishing several dependent podspecs

1. Sort them topologically, so dependencies are processed in the right order
2. When bumping a version, update its value in all referencing podspecs